### PR TITLE
Fix: Disable Tailwind CSS "Unknown at rule @apply"

### DIFF
--- a/roles/neovim/templates/config/lua/plugins/lsp.lua
+++ b/roles/neovim/templates/config/lua/plugins/lsp.lua
@@ -56,7 +56,15 @@ if lspconfig and cmp_nvim_lsp then
 
   lspconfig["cssls"].setup({
     capabilities = capabilities,
-    on_attach = on_attach
+    on_attach = on_attach,
+    settings = {
+      css = {
+        validate = true,
+        lint = {
+          unknownAtRules = "ignore"
+        }
+      }
+    }
   })
 
   lspconfig["graphql"].setup({
@@ -104,7 +112,15 @@ if lspconfig and cmp_nvim_lsp then
 
   lspconfig["tailwindcss"].setup({
     capabilities = capabilities,
-    on_attach = on_attach
+    on_attach = on_attach,
+    settings = {
+      tailwindcss = {
+        validate = true,
+        lint = {
+          invalidApply = false
+        }
+      }
+    }
   })
 
   lspconfig["ts_ls"].setup({

--- a/roles/vscodium/templates/settings.json
+++ b/roles/vscodium/templates/settings.json
@@ -7,6 +7,9 @@
   "editor.tabSize": 2,
   "explorer.compactFolders": false,
   "explorer.decorations.badges": false,
+  "files.associations": {
+    "*.css": "tailwindcss"
+  },
   "git.decorations.enabled": false,
   "vim.startInInsertMode": true,
   "vsicons.presets.hideExplorerArrows": true,


### PR DESCRIPTION
Disabled Tailwind CSS "Unknown at rule @apply" in VSCodium (and related IDEs like Cursor) and Neovim.