### PR TITLE
Feature: Add Watchman to Homebrew Packages List

### DIFF
--- a/group_vars/local.yml
+++ b/group_vars/local.yml
@@ -38,6 +38,7 @@ homebrew:
     - thefuck # 😂
     - tmux
     - volta
+    - watchman
     - wrk
     - zoxide
     - zsh


### PR DESCRIPTION
Watchman is required for running an Expo application in an iOS device simulator.